### PR TITLE
Changed super class of JSONObject from HashMap to LinkedHashMap to pr…

### DIFF
--- a/src/main/java/org/json/simple/JSONObject.java
+++ b/src/main/java/org/json/simple/JSONObject.java
@@ -7,8 +7,8 @@ package org.json.simple;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -16,7 +16,7 @@ import java.util.Map;
  * 
  * @author FangYidong<fangyidong@yahoo.com.cn>
  */
-public class JSONObject extends HashMap implements Map, JSONAware, JSONStreamAware{
+public class JSONObject extends LinkedHashMap implements Map, JSONAware, JSONStreamAware{
 	
 	private static final long serialVersionUID = -503443796854799292L;
 	


### PR DESCRIPTION
I changed the Super class of JSONObject from HashMap to LinkedHashMap to preserve insertion order. There are situations in which the insertion order of items in the JSON Object needs preservation due to a business requirement. 